### PR TITLE
Overwrite original query variables

### DIFF
--- a/multilingual-polylang.php
+++ b/multilingual-polylang.php
@@ -44,12 +44,11 @@ class MultilingualPolylang {
 
 		$all_languages = '';
 
-		$defaults = array(
-			'lang' => $all_languages,
-			'post__not_in' => $duplicated_post_ids,
-		);
+		$main_query = $GLOBALS['wp_query']->query;
+		$main_query['lang'] = $all_languages;
+		$main_query['post__not_in'] = $duplicated_post_ids;
 
-		$args = array_merge( $defaults, $args );
+		$args = array_merge( $main_query, $args );
 
 		return new WP_Query( $args );
 	}

--- a/multilingual-polylang.php
+++ b/multilingual-polylang.php
@@ -55,8 +55,12 @@ class MultilingualPolylang {
 		$merge_args['post__not_in'] = $duplicated_post_ids;
 
 		// Handle tax_query ([taxonomy] => language) arguments
-		$needle = self::getIndex('taxonomy', 'language', $merge_args['tax_query']);
-		unset($merge_args['tax_query'][$needle]);
+		if(isset($merge_args['tax_query'])) {
+			$needle = self::getIndex( 'taxonomy', 'language', $merge_args['tax_query'] );
+			if ( $needle !== null ) {
+				unset( $merge_args['tax_query'][ $needle ] );
+			}
+		}
 
 		// Give the possibility to overwrite the $args
 		$args = array_merge( $merge_args, $args );

--- a/multilingual-polylang.php
+++ b/multilingual-polylang.php
@@ -44,7 +44,7 @@ class MultilingualPolylang {
 
 		$all_languages = '';
 
-		$main_query = $GLOBALS['wp_query']->query;
+		$main_query = $wp_query->query;
 		$main_query['lang'] = $all_languages;
 		$main_query['post__not_in'] = $duplicated_post_ids;
 


### PR DESCRIPTION
This uses the original query variables from `$wp_query`and just overwrites the needed parts. This makes it campatible with taxonomy archives and fixes pagination issues.